### PR TITLE
feat: add support for superscripts, subscripts, and other functions

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -63,7 +63,7 @@ export default class AutoDisplaystyleInlineMathPlugin extends Plugin {
 					// I intentionally avoided "if (!options.display)" because MathJax.tex2chtml() seems to 
 					// return a display math even when "options" does not have "display" property.
 					if (options.display === false) {
-						if (settings.start) 
+						if (settings.front) 
 							source = '\\displaystyle ' + source;
 
 						if (settings.superscript) {

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,134 @@
+import { PluginSettingTab, Setting, App, Component, MarkdownRenderer } from 'obsidian';
+
+import AutoDisplaystyleInlineMathPlugin from 'main'
+
+export interface AutoDisplaystyleInlineMathSettings {
+	start: boolean;
+	superscript: boolean,
+	subscript: boolean,
+	additionalFunctionNames: string;
+}
+
+export const DEFAULT_SETTINGS: AutoDisplaystyleInlineMathSettings = {
+	start: true,
+	superscript: false,
+	subscript: false,
+	additionalFunctionNames: '',
+};
+
+export class AutoDisplaystyleInlineMathSettingTab extends PluginSettingTab {
+	plugin: AutoDisplaystyleInlineMathPlugin;
+    component: Component;
+    promises: Promise<any>[];
+  
+	constructor(app: App, plugin: AutoDisplaystyleInlineMathPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+        this.component = new Component();
+        this.promises = [];
+	}
+  
+	display(): void {
+		let { containerEl } = this;
+  
+		containerEl.empty();
+
+		new Setting(containerEl)
+			.setName("At start")
+			.setDesc("Whether to add \\displaystyle at the start of inline maths")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.start)
+				.onChange(async (value) => {
+					this.plugin.settings.start = value;
+					await this.plugin.saveSettings();
+					this.plugin.rerender();
+            }))
+            .then((setting) => {
+				this.renderMarkdown([
+                    'How it works:  `$\\sum_{i=1}^{N} i^{2}$` -> `$\\displaystyle \\sum_{i=1}^{N} i^{2}$`',
+                    'Effect:  $\\sum_{i=1}^{N} i^{2}$ -> $\\displaystyle \\sum_{i=1}^{N} i^{2}$',
+				], setting.descEl);
+			});
+
+		new Setting(containerEl)
+			.setName("Superscript")
+			.setDesc("Whether to add \\displaystyle to superscripts")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.superscript)
+				.onChange(async (value) => {
+					this.plugin.settings.superscript = value;
+					await this.plugin.saveSettings();
+					this.plugin.rerender();
+			}))
+            .then((setting) => {
+				this.renderMarkdown([
+                    'How it works: `$2^{3^4}$` -> `$2^{\\displaystyle 3^{\\displaystyle 4}}$`',
+                    'Effect: $2^{3^4}$ -> $2^{\\displaystyle 3^{\\displaystyle 4}}$',
+				], setting.descEl);
+			});
+
+		new Setting(containerEl)
+			.setName("Subscript")
+			.setDesc("Whether to add \\displaystyle to subscripts")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.subscript)
+				.onChange(async (value) => {
+					this.plugin.settings.subscript = value;
+					await this.plugin.saveSettings();
+					this.plugin.rerender();
+            }))
+            .then((setting) => {
+				this.renderMarkdown([
+                    'How it works: `$n_{a_{k+1}}$` -> `$n_{ \\displaystyle a_{\\displaystyle k+1}}$`',
+                    'Effect: $n_{a_{k+1}}$ -> $n_{\\displaystyle a_{\\displaystyle k+1}}$',
+				], setting.descEl);
+			});
+
+		new Setting(containerEl)
+			.setName("Additional functions to be prepended with \\displaystyle")
+			.setDesc("A list of function names to add \\displaystyle before them. (separated by commas)")
+			.addText((text) => {
+                text
+                    .setPlaceholder('example: frac, binom')
+                    .setValue(this.plugin.settings.additionalFunctionNames)
+                    .onChange(async (value) => {
+                        this.plugin.settings.additionalFunctionNames = value;
+
+                        await this.plugin.saveSettings();
+                });  
+
+                this.component.registerDomEvent(text.inputEl, 'blur', () => {
+                    this.plugin.rerender();
+                });
+                this.component.registerDomEvent(text.inputEl, 'keypress', (evt) => {
+                    if (evt.key === 'Enter') {
+                        this.plugin.rerender();
+                    }
+                });
+            })
+            .then((setting) => {
+				this.renderMarkdown([
+                    'How it works: `$\\frac{2 + \\binom{n}{i}}{1 + \\frac{3}{4}}$` -> `$\\displaystyle \\frac{2 + \\displaystyle \\binom{n}{i}}{1 + \\displaystyle \\frac{3}{4}}$`',
+                    'Effect: $\\frac{2 + \\binom{n}{i}}{1 + \\frac{3}{4}}$ -> $\\displaystyle \\frac{2 + \\displaystyle \\binom{n}{i}}{1 + \\displaystyle \\frac{3}{4}}$',
+				], setting.descEl);
+			});
+            
+	}
+
+    async renderMarkdown(lines: string[] | string, el: HTMLElement) {
+        // temporarily disable the plugin
+        // because I need to use the original rendering in plugin settings tab 
+        this.plugin.uninstaller?.();
+        this.promises.push(this._renderMarkdown(lines, el));
+        el.addClass('markdown-rendered');
+        // enable the plugin again
+        this.plugin.install();
+    }
+
+    async _renderMarkdown(lines: string[] | string, el: HTMLElement) {
+		await MarkdownRenderer.render(this.app, Array.isArray(lines) ? lines.join('\n') : lines, el, '', this.component);
+		if (el.childNodes.length === 1 && el.firstChild instanceof HTMLParagraphElement) {
+			el.replaceChildren(...el.firstChild.childNodes);
+		}
+	}
+}

--- a/settings.ts
+++ b/settings.ts
@@ -3,14 +3,14 @@ import { PluginSettingTab, Setting, App, Component, MarkdownRenderer } from 'obs
 import AutoDisplaystyleInlineMathPlugin from 'main'
 
 export interface AutoDisplaystyleInlineMathSettings {
-	start: boolean;
+	front: boolean;
 	superscript: boolean,
 	subscript: boolean,
 	additionalFunctionNames: string;
 }
 
 export const DEFAULT_SETTINGS: AutoDisplaystyleInlineMathSettings = {
-	start: true,
+	front: true,
 	superscript: false,
 	subscript: false,
 	additionalFunctionNames: '',
@@ -34,12 +34,12 @@ export class AutoDisplaystyleInlineMathSettingTab extends PluginSettingTab {
 		containerEl.empty();
 
 		new Setting(containerEl)
-			.setName("At start")
-			.setDesc("Whether to add \\displaystyle at the start of inline maths")
+			.setName("Front")
+			.setDesc("Whether to add \\displaystyle at the front of an inline math.")
 			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.start)
+				.setValue(this.plugin.settings.front)
 				.onChange(async (value) => {
-					this.plugin.settings.start = value;
+					this.plugin.settings.front = value;
 					await this.plugin.saveSettings();
 					this.plugin.rerender();
             }))

--- a/settings.ts
+++ b/settings.ts
@@ -52,7 +52,7 @@ export class AutoDisplaystyleInlineMathSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Superscript")
-			.setDesc("Whether to add \\displaystyle to superscripts")
+			.setDesc("Whether to add \\displaystyle to each superscript in an inline math.")
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.superscript)
 				.onChange(async (value) => {
@@ -69,7 +69,7 @@ export class AutoDisplaystyleInlineMathSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Subscript")
-			.setDesc("Whether to add \\displaystyle to subscripts")
+			.setDesc("Whether to add \\displaystyle to each subscript in an inline math.")
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.subscript)
 				.onChange(async (value) => {
@@ -86,7 +86,7 @@ export class AutoDisplaystyleInlineMathSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Additional functions to be prepended with \\displaystyle")
-			.setDesc("A list of function names to add \\displaystyle before them. (separated by commas)")
+			.setDesc("A list of function names (separated by commas), where each instance of these functions in an inline math will be prepended with \\displaystyle.")
 			.addText((text) => {
                 text
                     .setPlaceholder('example: frac, binom')


### PR DESCRIPTION
Thank you for this great plugin, it's very useful.

I find that adding `\displaystyle` at the front of the inline maths can't cover some cases.
Especially for superscripts (`^`) and subscripts (`_`), which I use a lot. So I add 4 settings ("front", "superscript", "subscripts", and "additional functions") in plugin's settings tab to make it more powerful. 

# Features
## superscripts and subscripts
For example, 
![image](https://github.com/user-attachments/assets/007e2c96-53c6-4c76-aea2-1cfca0a467de)
As the screenshot shows, if we only add `\displaystyle` at the front, the superscript `3` and `4` wouldn't be in displaystyle. Instead, we have to add `\displaystyle` for each superscript (`^`).

![image](https://github.com/user-attachments/assets/2ecfe354-63f6-4f45-83a5-a1757a1a5e5b)
Similarly, if we only add `\displaystyle` at the front, the subscript `a` and `k+1` wouldn't be in displaystyle. Instead, we have to add `\displaystyle` for each subscript (`_`).

For some cases, we even need to apply all "add `\displaystyle` at the front", "add `\displaystyle` for each subscript (`^`)" and "add `\displaystyle` for each subscript (`_`)" to make every element in an inline math to be in displaystyle.  
![image](https://github.com/user-attachments/assets/aa3b3fb7-914b-4e08-9c65-0f6a66a1d788)

For these 3 options ("front", "superscript", "subscript"), users can toggle them in plugin's settings tab. If users toggle "front" on, and toggle both "superscript" and "subscript" off, then it would be the exact same as the plugin's original behavior (only add `\displaystyle` at the front of an inline math). 
![image](https://github.com/user-attachments/assets/9de4cf86-37b5-4cf6-85a0-3ae2d552766d)

## Additional functions
Some cases still can't be covered by discussion above.
For example,
![image](https://github.com/user-attachments/assets/0f0a60a3-3a3f-4198-905c-5c92d20eeb4e)
As the screenshot shows, we have to put `\displaystyle` in front of each `\frac` and `\binom` to make them be in displaystyle, which is different from the handling for superscripts (`^`) and subscripts (`_`).  (when dealing with superscripts and subscripts, we put `\displaystyle` into the curly braces `{}` behind `^` or `_`.) 
During my daily usage, I only encounter `\frac`, `\binom`, but I suppose that some users might need support for other functions, so I add an text option in the settings tab.
Users can use string like "frac, binom" (function names separated by commas) to specify which functions to be prepended with `\displaystyle`.
![image](https://github.com/user-attachments/assets/b60b8976-890b-46b7-84c6-0c91beec65e4)

# Testing
Here is a markdown file for simple testing. 
[testing.md](https://github.com/user-attachments/files/16401060/testing.md)

P.S. You may found some lines of code familiar (eg: `renderMarkdown()`). Because I copy paste those lines from your another awesome plugin [obsidian-pdf-plus](https://github.com/RyotaUshio/obsidian-pdf-plus). Hope you don't mind it. 
